### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -1,4 +1,6 @@
 name: Build and Push to Docker Hub
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/LukasNespor/document-templates/security/code-scanning/1](https://github.com/LukasNespor/document-templates/security/code-scanning/1)

To fix the problem, we need to add a `permissions` block to the workflow file `.github/workflows/docker-build-push.yml`. The least privilege required for this job is `contents: read`, since its only access to the repository is to check out code for building Docker images. This `permissions` block should be added near the top of the file, right under the `name:` (to apply for all jobs unless specifically overridden). No additional imports or other changes are necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
