### PR TITLE
Update help dialog to mention template download feature

### DIFF
--- a/components/HelpDialog.tsx
+++ b/components/HelpDialog.tsx
@@ -112,7 +112,8 @@ export default function HelpDialog({ isOpen, onClose }: HelpDialogProps) {
             </h4>
             <p className="text-gray-600 mb-4">
               U každé šablony můžete upravit název, poznámku a skupinu (tlačítko Upravit),
-              znovu nahrát soubor šablony (tlačítko Znovu nahrát), nebo šablonu smazat (tlačítko Smazat).
+              znovu nahrát soubor šablony (tlačítko Znovu nahrát), stáhnout původní Word šablonu (.docx),
+              nebo šablonu smazat (tlačítko Smazat).
             </p>
 
                   <h4 className="font-semibold text-gray-800 mb-2">Tipy</h4>


### PR DESCRIPTION
Added note in Section 4 (Správa šablon) that users can now download the original Word template (.docx) file in addition to editing, re-uploading, and deleting templates.