### PR TITLE
Fix SESSION_SECRET validation to defer until runtime

### DIFF
--- a/lib/session-config.ts
+++ b/lib/session-config.ts
@@ -6,38 +6,83 @@
 
 import { SessionOptions } from "iron-session";
 
-// Validate SESSION_SECRET exists in production
-const sessionSecret = process.env.SESSION_SECRET;
-const isProduction = process.env.NODE_ENV === "production";
+/**
+ * Validates SESSION_SECRET configuration at runtime
+ * This is called lazily to avoid build-time failures when SESSION_SECRET isn't available
+ */
+let hasValidated = false;
+function validateSessionSecret() {
+  if (hasValidated) return;
+  hasValidated = true;
 
-if (!sessionSecret && isProduction) {
-  throw new Error(
-    "SESSION_SECRET environment variable is required in production. " +
-    "Please set a secure random string of at least 32 characters."
-  );
-}
+  const sessionSecret = process.env.SESSION_SECRET;
+  const isProduction = process.env.NODE_ENV === "production";
 
-if (sessionSecret && sessionSecret.length < 32) {
-  console.warn(
-    "WARNING: SESSION_SECRET should be at least 32 characters long for security. " +
-    `Current length: ${sessionSecret.length} characters.`
-  );
+  if (!sessionSecret && isProduction) {
+    throw new Error(
+      "SESSION_SECRET environment variable is required in production. " +
+      "Please set a secure random string of at least 32 characters."
+    );
+  }
+
+  if (sessionSecret && sessionSecret.length < 32) {
+    console.warn(
+      "WARNING: SESSION_SECRET should be at least 32 characters long for security. " +
+      `Current length: ${sessionSecret.length} characters.`
+    );
+  }
 }
 
 /**
- * Session configuration options for iron-session
+ * Gets session configuration options for iron-session
  * Used consistently across lib/auth.ts and middleware.ts
+ * Validates SESSION_SECRET on first access
  */
-export const sessionOptions: SessionOptions = {
-  password: sessionSecret || "complex_password_at_least_32_characters_long_change_this",
-  cookieName: "word_templates_session",
-  cookieOptions: {
-    secure: isProduction,
-    httpOnly: true,
-    sameSite: "lax",
-    maxAge: 60 * 60 * 24 * 7, // 7 days
+function getSessionOptions(): SessionOptions {
+  const sessionSecret = process.env.SESSION_SECRET;
+  const isProduction = process.env.NODE_ENV === "production";
+
+  return {
+    password: sessionSecret || "complex_password_at_least_32_characters_long_change_this",
+    cookieName: "word_templates_session",
+    cookieOptions: {
+      secure: isProduction,
+      httpOnly: true,
+      sameSite: "lax",
+      maxAge: 60 * 60 * 24 * 7, // 7 days
+    },
+  };
+}
+
+/**
+ * Lazy-initialized session options
+ * Uses Proxy to validate SESSION_SECRET only when actually accessed at runtime
+ */
+let cachedOptions: SessionOptions | null = null;
+
+export const sessionOptions = new Proxy({} as SessionOptions, {
+  get(_target, prop) {
+    if (!cachedOptions) {
+      validateSessionSecret();
+      cachedOptions = getSessionOptions();
+    }
+    return cachedOptions[prop as keyof SessionOptions];
   },
-};
+  ownKeys(_target) {
+    if (!cachedOptions) {
+      validateSessionSecret();
+      cachedOptions = getSessionOptions();
+    }
+    return Reflect.ownKeys(cachedOptions);
+  },
+  getOwnPropertyDescriptor(_target, prop) {
+    if (!cachedOptions) {
+      validateSessionSecret();
+      cachedOptions = getSessionOptions();
+    }
+    return Reflect.getOwnPropertyDescriptor(cachedOptions, prop);
+  }
+});
 
 /**
  * Session duration in seconds (7 days)


### PR DESCRIPTION
Resolves Docker build failure where SESSION_SECRET validation was happening at module load time during the build process. The validation now uses a Proxy pattern to defer checking until the sessionOptions are actually accessed at runtime.

This allows the Docker build to complete successfully while still maintaining security validation when the application starts serving requests in production.

Technical changes:
- Wrapped sessionOptions export in a Proxy with lazy initialization
- Moved validation logic to validateSessionSecret() function
- Validation cached after first access for performance
- Backward compatible with existing code using sessionOptions