### PR TITLE
Add canBulkGenerate permission feature flag

### DIFF
--- a/app/api/admin/users/route.ts
+++ b/app/api/admin/users/route.ts
@@ -27,6 +27,7 @@ export async function GET() {
       createdAt: user.createdAt,
       salutation: user.salutation,
       isAdmin: user.isAdmin,
+      canBulkGenerate: user.canBulkGenerate,
     }));
 
     return NextResponse.json({ users: sanitizedUsers });
@@ -52,7 +53,7 @@ export async function POST(request: NextRequest) {
     }
 
     const body = await request.json();
-    const { username, password, salutation, isAdmin } = body;
+    const { username, password, salutation, isAdmin, canBulkGenerate } = body;
 
     // Validate input using centralized validation
     const validation = validateCredentials(username, password);
@@ -82,6 +83,7 @@ export async function POST(request: NextRequest) {
       createdAt: new Date().toISOString(),
       salutation: salutation || undefined,
       isAdmin: isAdmin || false,
+      canBulkGenerate: canBulkGenerate || false,
     };
 
     await saveUser(newUser);
@@ -94,6 +96,7 @@ export async function POST(request: NextRequest) {
         createdAt: newUser.createdAt,
         salutation: newUser.salutation,
         isAdmin: newUser.isAdmin,
+        canBulkGenerate: newUser.canBulkGenerate,
       },
     });
   } catch (error) {

--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -53,6 +53,7 @@ export async function POST(request: NextRequest) {
     session.username = user.username;
     session.salutation = user.salutation;
     session.isAdmin = user.isAdmin;
+    session.canBulkGenerate = user.canBulkGenerate;
     session.isLoggedIn = true;
     await session.save();
 
@@ -66,6 +67,7 @@ export async function POST(request: NextRequest) {
         username: user.username,
         salutation: user.salutation,
         isAdmin: user.isAdmin,
+        canBulkGenerate: user.canBulkGenerate,
       },
     });
   } catch (error) {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -33,6 +33,7 @@ export default function Home() {
   const [username, setUsername] = useState<string | null>(null);
   const [salutation, setSalutation] = useState<string | null>(null);
   const [isAdmin, setIsAdmin] = useState(false);
+  const [canBulkGenerate, setCanBulkGenerate] = useState(false);
   const [userId, setUserId] = useState<string>("");
   const [isUserManagementOpen, setIsUserManagementOpen] = useState(false);
 
@@ -67,6 +68,7 @@ export default function Home() {
         setUsername(data.user.username);
         setSalutation(data.user.salutation || null);
         setIsAdmin(data.user.isAdmin || false);
+        setCanBulkGenerate(data.user.canBulkGenerate || false);
         setUserId(data.user.userId || "");
       }
     } catch (error) {
@@ -387,7 +389,7 @@ export default function Home() {
               onDeleteTemplate={handleDeleteTemplate}
               onReuploadTemplate={handleReuploadTemplate}
               onHelp={() => setIsHelpOpen(true)}
-              onBulkGenerate={() => setIsBulkGenerateOpen(true)}
+              onBulkGenerate={canBulkGenerate ? () => setIsBulkGenerateOpen(true) : undefined}
             />
           ) : (
             <div className="flex flex-col items-center justify-center min-h-[400px] bg-gradient-to-br from-white to-blue-50 rounded-2xl shadow-xl border border-gray-200 p-8">
@@ -543,7 +545,11 @@ export default function Home() {
       </div>
 
       {/* Dialogs */}
-      <HelpDialog isOpen={isHelpOpen} onClose={() => setIsHelpOpen(false)} />
+      <HelpDialog
+        isOpen={isHelpOpen}
+        onClose={() => setIsHelpOpen(false)}
+        canBulkGenerate={canBulkGenerate}
+      />
       <UploadTemplateDialog
         isOpen={isUploadOpen}
         onClose={() => setIsUploadOpen(false)}
@@ -572,7 +578,11 @@ export default function Home() {
       />
       <UserManagementDialog
         isOpen={isUserManagementOpen}
-        onClose={() => setIsUserManagementOpen(false)}
+        onClose={() => {
+          setIsUserManagementOpen(false);
+          // Reload session in case user edited their own profile
+          checkSession();
+        }}
         currentUserId={userId}
       />
     </div>

--- a/components/HelpDialog.tsx
+++ b/components/HelpDialog.tsx
@@ -6,9 +6,10 @@ import { X, ChevronDown, ChevronUp } from "lucide-react";
 interface HelpDialogProps {
   isOpen: boolean;
   onClose: () => void;
+  canBulkGenerate?: boolean;
 }
 
-export default function HelpDialog({ isOpen, onClose }: HelpDialogProps) {
+export default function HelpDialog({ isOpen, onClose, canBulkGenerate = false }: HelpDialogProps) {
   const [openSection, setOpenSection] = useState<string | null>(null);
   const mouseDownOnBackdrop = useRef(false);
 
@@ -71,7 +72,7 @@ export default function HelpDialog({ isOpen, onClose }: HelpDialogProps) {
               {openSection === "start" && (
                 <div className="p-6 bg-white">
                   <p className="text-gray-600 mb-4">
-                    Tato aplikace vám pomůže vytvářet Word dokumenty ze šablon. Můžete generovat jednotlivé dokumenty nebo hromadně z CSV souboru.
+                    Tato aplikace vám pomůže vytvářet Word dokumenty ze šablon. {canBulkGenerate ? "Můžete generovat jednotlivé dokumenty nebo hromadně z CSV souboru." : ""}
                   </p>
 
             <h4 className="font-semibold text-gray-800 mb-2">
@@ -91,21 +92,25 @@ export default function HelpDialog({ isOpen, onClose }: HelpDialogProps) {
             </p>
 
             <h4 className="font-semibold text-gray-800 mb-2">
-              3a. Generovat jeden dokument
+              {canBulkGenerate ? "3a. Generovat jeden dokument" : "3. Generovat dokument"}
             </h4>
             <p className="text-gray-600 mb-4">
               Vyplňte hodnoty pro každé pole a zadejte název výsledného souboru.
               Klikněte na tlačítko &quot;Vygenerovat dokument&quot; a dokument se stáhne do vašeho počítače.
             </p>
 
-            <h4 className="font-semibold text-gray-800 mb-2">
-              3b. Hromadné generování z CSV
-            </h4>
-            <p className="text-gray-600 mb-4">
-              Pro generování více dokumentů najednou klikněte na zelené tlačítko &quot;Nahrát CSV&quot; v horní části šablony.
-              Nahrajte CSV soubor (oddělený středníky), kde první sloupec obsahuje názvy souborů a další sloupce odpovídají
-              polím v šabloně. Stáhne se ZIP soubor se všemi vygenerovanými dokumenty.
-            </p>
+            {canBulkGenerate && (
+              <>
+                <h4 className="font-semibold text-gray-800 mb-2">
+                  3b. Hromadné generování z CSV
+                </h4>
+                <p className="text-gray-600 mb-4">
+                  Pro generování více dokumentů najednou klikněte na zelené tlačítko &quot;Nahrát CSV&quot; v horní části šablony.
+                  Nahrajte CSV soubor (oddělený středníky), kde první sloupec obsahuje názvy souborů a další sloupce odpovídají
+                  polím v šabloně. Stáhne se ZIP soubor se všemi vygenerovanými dokumenty.
+                </p>
+              </>
+            )}
 
             <h4 className="font-semibold text-gray-800 mb-2">
               4. Správa šablon
@@ -121,7 +126,9 @@ export default function HelpDialog({ isOpen, onClose }: HelpDialogProps) {
                     <div>Používejte popisné názvy pro pole (např. {"{{"} Jméno {"}}"}, {"{{"} Č.J. {"}}"})</div>
                     <div>Seskupujte související šablony do skupin pro lepší přehlednost</div>
                     <div>Přidejte poznámky k šablonám pro zapamatování jejich účelu</div>
-                    <div>Pro hromadné generování připravte CSV soubor s daty v Excelu</div>
+                    {canBulkGenerate && (
+                      <div>Pro hromadné generování připravte CSV soubor s daty v Excelu</div>
+                    )}
                   </div>
                 </div>
               )}
@@ -200,21 +207,22 @@ export default function HelpDialog({ isOpen, onClose }: HelpDialogProps) {
             </div>
 
             {/* Section 3: Jak exportovat Excel do CSV */}
-            <div className="border border-gray-200 rounded-xl overflow-hidden">
-              <button
-                onClick={() => toggleSection("csv")}
-                className="w-full bg-gradient-to-r from-green-50 to-green-100 hover:from-green-100 hover:to-green-150 p-5 flex items-center justify-between transition-colors"
-              >
-                <h3 className="text-xl font-bold text-gray-900">
-                  Jak exportovat Excel do CSV pro hromadné generování
-                </h3>
-                {openSection === "csv" ? (
-                  <ChevronUp className="w-6 h-6 text-green-600 flex-shrink-0" />
-                ) : (
-                  <ChevronDown className="w-6 h-6 text-green-600 flex-shrink-0" />
-                )}
-              </button>
-              {openSection === "csv" && (
+            {canBulkGenerate && (
+              <div className="border border-gray-200 rounded-xl overflow-hidden">
+                <button
+                  onClick={() => toggleSection("csv")}
+                  className="w-full bg-gradient-to-r from-green-50 to-green-100 hover:from-green-100 hover:to-green-150 p-5 flex items-center justify-between transition-colors"
+                >
+                  <h3 className="text-xl font-bold text-gray-900">
+                    Jak exportovat Excel do CSV pro hromadné generování
+                  </h3>
+                  {openSection === "csv" ? (
+                    <ChevronUp className="w-6 h-6 text-green-600 flex-shrink-0" />
+                  ) : (
+                    <ChevronDown className="w-6 h-6 text-green-600 flex-shrink-0" />
+                  )}
+                </button>
+                {openSection === "csv" && (
                 <div className="p-6 bg-white">
                   <p className="text-gray-600 mb-4">
                     Pro hromadné generování dokumentů z Excelu je potřeba soubor uložit jako CSV se středníkovým oddělovačem:
@@ -274,7 +282,8 @@ export default function HelpDialog({ isOpen, onClose }: HelpDialogProps) {
                   </div>
                 </div>
               )}
-            </div>
+              </div>
+            )}
           </div>
         </div>
       </div>

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -46,7 +46,7 @@ export async function isAuthenticated(): Promise<boolean> {
 /**
  * Get the current user from session
  */
-export async function getCurrentUser(): Promise<{ userId: string; username: string; salutation?: string; isAdmin?: boolean } | null> {
+export async function getCurrentUser(): Promise<{ userId: string; username: string; salutation?: string; isAdmin?: boolean; canBulkGenerate?: boolean } | null> {
   const session = await getSession();
   if (session.isLoggedIn && session.userId && session.username) {
     return {
@@ -54,6 +54,7 @@ export async function getCurrentUser(): Promise<{ userId: string; username: stri
       username: session.username,
       salutation: session.salutation,
       isAdmin: session.isAdmin,
+      canBulkGenerate: session.canBulkGenerate,
     };
   }
   return null;

--- a/lib/azure-users.ts
+++ b/lib/azure-users.ts
@@ -53,6 +53,7 @@ export async function saveUser(user: User): Promise<void> {
     createdAt: user.createdAt,
     salutation: user.salutation || "",
     isAdmin: user.isAdmin || false,
+    canBulkGenerate: user.canBulkGenerate || false,
   };
 
   await tableClient.upsertEntity(entity);
@@ -60,7 +61,7 @@ export async function saveUser(user: User): Promise<void> {
 
 export async function updateUser(
   userId: string,
-  updates: { username?: string; passwordHash?: string; salutation?: string; isAdmin?: boolean }
+  updates: { username?: string; passwordHash?: string; salutation?: string; isAdmin?: boolean; canBulkGenerate?: boolean }
 ): Promise<User> {
   const tableClient = getUserTableClient();
 
@@ -77,6 +78,7 @@ export async function updateUser(
     ...(updates.passwordHash !== undefined && { passwordHash: updates.passwordHash }),
     ...(updates.salutation !== undefined && { salutation: updates.salutation }),
     ...(updates.isAdmin !== undefined && { isAdmin: updates.isAdmin }),
+    ...(updates.canBulkGenerate !== undefined && { canBulkGenerate: updates.canBulkGenerate }),
   };
 
   // Save updated user
@@ -88,6 +90,7 @@ export async function updateUser(
     createdAt: updatedUser.createdAt,
     salutation: updatedUser.salutation || "",
     isAdmin: updatedUser.isAdmin || false,
+    canBulkGenerate: updatedUser.canBulkGenerate || false,
   };
 
   await tableClient.upsertEntity(entity);
@@ -107,6 +110,7 @@ export async function getUserById(id: string): Promise<User | null> {
       createdAt: entity.createdAt as string,
       salutation: (entity.salutation as string) || undefined,
       isAdmin: (entity.isAdmin as boolean) || false,
+      canBulkGenerate: (entity.canBulkGenerate as boolean) || false,
     };
   } catch (error) {
     return null;
@@ -128,6 +132,7 @@ export async function getUserByUsername(username: string): Promise<User | null> 
       createdAt: entity.createdAt as string,
       salutation: (entity.salutation as string) || undefined,
       isAdmin: (entity.isAdmin as boolean) || false,
+      canBulkGenerate: (entity.canBulkGenerate as boolean) || false,
     };
   }
 
@@ -172,6 +177,7 @@ export async function getAllUsers(): Promise<User[]> {
       createdAt: entity.createdAt as string,
       salutation: (entity.salutation as string) || undefined,
       isAdmin: (entity.isAdmin as boolean) || false,
+      canBulkGenerate: (entity.canBulkGenerate as boolean) || false,
     });
   }
 

--- a/types/index.ts
+++ b/types/index.ts
@@ -46,6 +46,7 @@ export interface User {
   createdAt: string;
   salutation?: string;
   isAdmin?: boolean;
+  canBulkGenerate?: boolean;
 }
 
 export interface SessionData {
@@ -54,4 +55,5 @@ export interface SessionData {
   isLoggedIn: boolean;
   salutation?: string;
   isAdmin?: boolean;
+  canBulkGenerate?: boolean;
 }


### PR DESCRIPTION
This commit implements a feature flag system for bulk CSV document generation:

## Changes

### Data Model
- Add canBulkGenerate field to User and SessionData interfaces
- Update Azure Table Storage operations to persist the new field

### Authentication & Session
- Store canBulkGenerate in session during login
- Return canBulkGenerate in session API responses
- Update session when user edits their own permissions

### User Management
- Add checkbox in UserManagementDialog for "Hromadné generování z CSV"
- Allow admins to edit only permissions on their own account
- Hide username, salutation, and password change for self-editing
- Support partial updates in admin user API endpoint

### UI & UX
- Conditionally show CSV upload container based on canBulkGenerate
- Update HelpDialog to show CSV-related sections only for authorized users
- Adjust help section numbering (3a/3b vs just 3) based on permissions

### API Endpoints
- GET /api/admin/users - Include canBulkGenerate in response
- POST /api/admin/users - Accept canBulkGenerate when creating users
- PUT /api/admin/users/[id] - Support partial updates with canBulkGenerate
- POST /api/auth/login - Store canBulkGenerate in session

## User Experience
Users without canBulkGenerate permission:
- Do not see the green CSV upload container
- Do not see CSV-related help sections
- Cannot access bulk generation features

Admins can manage their own canBulkGenerate permission through user management dialog.